### PR TITLE
Fix error: No command '-bash' found

### DIFF
--- a/ve.sh
+++ b/ve.sh
@@ -38,7 +38,7 @@ ve() {
         local key=`dirname $key`
         [ "$key" != "/" ]
       do :; done
-      $0 -h
+      ve -h
       return
       ;;
 
@@ -56,7 +56,7 @@ ve() {
 
       if [ -z "$2" ]; then
         echo 'Not enough argument'
-        $0 -h
+        ve -h
         return
       fi
 


### PR DESCRIPTION
To fix this error
```sh
No command '-bash' found, did you mean:
 Command 'rbash' from package 'bash' (main)
 Command 'bash' from package 'bash' (main)
-bash: command not found
```